### PR TITLE
[circuit]: Import the `noir-web-prover-circuits` as a dependency

### DIFF
--- a/noir/Nargo.toml
+++ b/noir/Nargo.toml
@@ -1,4 +1,4 @@
 [workspace]
 members = [
-"my_noir"
+  "my_noir"
 ]

--- a/noir/my_noir/Nargo.toml
+++ b/noir/my_noir/Nargo.toml
@@ -1,7 +1,13 @@
 [package]
 name = "my_noir"
 type = "bin"
-authors = [""]
-compiler_version = ">=0.35.0"
+authors = ["masaun"]
+compiler_version = ">=1.0.0"
+#compiler_version = ">=0.35.0"
+version = "0.0.1"
 
 [dependencies]
+# zkTLS
+noir_web_prover = { tag = "feat/package-updates_poseidon", git = "https://github.com/masaun/noir-web-prover-circuits", directory = "http" }
+#noir_web_prover = { tag = "main", git = "https://github.com/pluto/noir-web-prover-circuits", directory = "http" }
+poseidon = { git = "https://github.com/noir-lang/poseidon", tag = "v0.1.1" }


### PR DESCRIPTION

- `noir-web-prover-circuits` : https://github.com/pluto/noir-web-prover-circuits