### PR TITLE
[circuit test]: Concating the whole API response (header + body) in bytes - via the `.concat()` method

### DIFF
--- a/noir/zktls-integrations/src/tests/test_http_data_generator_for_dex_api_response_header_and_body.nr
+++ b/noir/zktls-integrations/src/tests/test_http_data_generator_for_dex_api_response_header_and_body.nr
@@ -33,6 +33,10 @@ fn generate_test_http_data_for_DEX_API_response_header_and_body() {
     let response_body_plain_text = response_body_plain_test();
     let response_body_bytes = response_body_plain_text.as_bytes().map(|x: u8| x);
     println(f"Response Body (in bytes): {response_body_bytes}\n");  // @dev - [Result]: Successful to convert the response from string to bytes ([u8; N])
+
+    // @dev - Concatenating the whole API response (header + body) in bytes
+    let response_bytes = response_header_bytes.concat(response_body_bytes);
+    println(f"Response (header + body in bytes): {response_bytes}\n");
 }
 
 

--- a/noir/zktls-integrations/src/zktls/test_http_data_okx_dex_api.nr
+++ b/noir/zktls-integrations/src/zktls/test_http_data_okx_dex_api.nr
@@ -9,13 +9,23 @@ use crate::tests::{
     }
 };
 
-// HTTP/1.1 200 OK
-// content-type: application/json; charset=utf-8
-// content-encoding: gzip
-// Transfer-Encoding: chunked
 
-pub fn response() -> [u8; 1] {
-    [1] // [TODO]: Replace with actual response data
+
+/**
+ * @notice - API response (header + body) in bytes format.
+ */
+pub fn response() -> [u8; 4185] {
+    let response_header_plain_text = response_header_plain_test();
+    let response_header_bytes = response_header_plain_text.as_bytes().map(|x: u8| x);
+
+    let response_body_plain_text = response_body_plain_test();
+    let response_body_bytes = response_body_plain_text.as_bytes().map(|x: u8| x);
+
+    let response_bytes = response_header_bytes.concat(response_body_bytes);
+
+    println(f"Response (header + body in bytes): {response_bytes}\n");
+
+    response_bytes
 }
 
 


### PR DESCRIPTION
# [circuit test]: Concating the whole API response (header + body) in bytes - via the `.concat()` method

## ref `concat()` method
   
- https://noir-lang.org/docs/noir/concepts/data_types/arrays#concat